### PR TITLE
Remove Errors Filter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -268,9 +268,6 @@
 		include_once ( PARENT_DIR . '/includes/tm-chat/class-cherry-tm-chat.php' );
 	}
 
-	// removes detailed login error information for security
-	add_filter('login_errors',create_function('$a', "return null;"));
-
 	/*
 	 * Loads the Options Panel
 	 *


### PR DESCRIPTION
The Error Filter can cause Problems with Themes and Plugins who use this function. It should be the users choice in a child theme if he want's to disable these messages or not. It should be removed from core framework.