### PR TITLE
Failsafe swap to WP core's jQuery

### DIFF
--- a/includes/theme-scripts.php
+++ b/includes/theme-scripts.php
@@ -5,11 +5,7 @@
 function cherry_scripts() {
 	if (!is_admin()) {
 		// CherryFramework Scripts
-		wp_deregister_script('jquery');
-		wp_register_script('jquery', PARENT_URL.'/js/jquery-1.7.2.min.js', false, '1.7.2');
-		wp_enqueue_script('jquery');
-		wp_register_script('migrate', PARENT_URL.'/js/jquery-migrate-1.2.1.min.js', array('jquery'), '1.2.1');
-		wp_enqueue_script('migrate');
+		wp_add_inline_script( 'jquery-core', 'var $ = jQuery.noConflict();', 'after' );
 
 		wp_register_script('modernizr', PARENT_URL.'/js/modernizr.js', array('jquery'), '2.0.6');
 		wp_register_script('jflickrfeed', PARENT_URL.'/js/jflickrfeed.js', array('jquery'), '1.0');


### PR DESCRIPTION
This should provide a failsafe transition from 1.7.2 to embedded jQuery core, while keeping old scripts intact.