### PR TITLE
Update public.js

### DIFF
--- a/includes/tm-chat/assets/js/public.js
+++ b/includes/tm-chat/assets/js/public.js
@@ -1,6 +1,6 @@
 (function($) {
 
-	$(window).load(function(){
+	$(window).on('load', function(){
 
 		var _this    = $('#tm-chat-dialog'),
 			$heading = $('.chat_box_heading'),


### PR DESCRIPTION
change .load() to .on(load) - fixing deprecated jQuery for WP 5.5